### PR TITLE
Add NAME_ISO_DEP_MAX_TRANSCEIVE_LENGTH

### DIFF
--- a/src/include/config.h
+++ b/src/include/config.h
@@ -90,6 +90,7 @@ int GetNumValue(const char* name, void* p_value, unsigned long len);
 #define NAME_NCI_HAL_MODULE             "NCI_HAL_MODULE"
 #define NAME_NFA_POLL_BAIL_OUT_MODE     "NFA_POLL_BAIL_OUT_MODE"
 #define NAME_NFA_PROPRIETARY_CFG        "NFA_PROPRIETARY_CFG"
+#define NAME_ISO_DEP_MAX_TRANSCEIVE "ISO_DEP_MAX_TRANSCEIVE"
 
 #define                     LPTD_PARAM_LEN (40)
 


### PR DESCRIPTION
Bug: 37005118
Test: Test if the config is read correctly
Change-Id: I75ac2f533016ab1bd1bc05879aa821c9a8729a37

IT fixes the NFC app in nougat-mr2 branch which comes from los repo
https://github.com/LineageOS/android_packages_apps_Nfc

Without this line all nougat-mr2 builds fail for all phones since 9 days ago. 